### PR TITLE
Removed `width = ` parameters for images.

### DIFF
--- a/notebooks/api-foundations/api-basics.ipynb
+++ b/notebooks/api-foundations/api-basics.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=300 alt=\"Project Pythia Logo\"></img> <img src=\"https://images.unsplash.com/photo-1571171637578-41bc2dd41cd2?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\" width=400, alt=\"Computer code displayed on dual monitors (October 15, 2019)\"></img>\n",
+    "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=300 alt=\"Project Pythia Logo\"></img> <img src=\"https://images.unsplash.com/photo-1571171637578-41bc2dd41cd2?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\" alt=\"Computer code displayed on dual monitors (October 15, 2019)\"></img>\n",
     "Photo by <a href=\"https://unsplash.com/@ffstop?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash\">Fotis Fotopoulos</a> on <a href=\"https://unsplash.com/photos/black-computer-keyboard-DuHKoV44prg?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash\">Unsplash</a>"
    ]
   },

--- a/notebooks/example-workflows/air-quality-system-api.ipynb
+++ b/notebooks/example-workflows/air-quality-system-api.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=300 alt=\"Project Pythia Logo\"></img><img src=\"https://images.unsplash.com/photo-1686179225818-c07909cd2911?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\" width=300, alt=\"Wildfire smoke over New York City (June 7, 2023)\"></img>\n",
+    "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=300 alt=\"Project Pythia Logo\"></img><img src=\"https://images.unsplash.com/photo-1686179225818-c07909cd2911?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\" alt=\"Wildfire smoke over New York City (June 7, 2023)\"></img>\n",
     "Photo by <a href=\"https://unsplash.com/@ahmerkalam?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash\">Ahmer Kalam</a> on <a href=\"https://unsplash.com/photos/a-foggy-city-skyline-with-the-sun-in-the-distance-Reuk1nmutFI?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash\">Unsplash</a>"
    ]
   },

--- a/notebooks/example-workflows/wfm-cloud-water.ipynb
+++ b/notebooks/example-workflows/wfm-cloud-water.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=300 alt=\"Project Pythia Logo\"></img>\n",
     "\n",
-    "<img src=\"https://whiteface.asrc.albany.edu/images/header_ASRC-WFM_750.png\" width=500, alt=\"Atmospheric Sciences Research Center Whiteface Mountain Field Station logo\"></img><p>"
+    "<img src=\"https://whiteface.asrc.albany.edu/images/header_ASRC-WFM_750.png\" alt=\"Atmospheric Sciences Research Center Whiteface Mountain Field Station logo\"></img><p>"
    ]
   },
   {


### PR DESCRIPTION
This should resolve the issues with the website and `api-basics`, `air-quality-system-api`, and `wfm-cloud-water` notebooks.

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
